### PR TITLE
fixed recipe picture modal on desktop

### DIFF
--- a/src/app/recipe/recipe.component.scss
+++ b/src/app/recipe/recipe.component.scss
@@ -162,5 +162,7 @@ li {
 .random-image {
     margin-top: -16px;
     margin-left: -15px;
+    //to accomondate the whole modal
+    width: 106.5%;
     max-width: 94.5vw;
 }


### PR DESCRIPTION
- Pictures in recipe pictures modal were larger than the modal on desktop. Fixed by setting width to the picture.